### PR TITLE
Fix extension description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(MONAIViz)
 set(EXTENSION_HOMEPAGE "https://github.com/Project-MONAI/SlicerMONAIViz#slicermonaiviz")
 set(EXTENSION_CATEGORY "Developer Tools")
 set(EXTENSION_CONTRIBUTORS "MONAI Consortium")
-set(EXTENSION_DESCRIPTION "This extension helps to run chain of MONAI transforms and visualize every stage over an image/label. See more information in <a href=\"https://github.com/Project-MONAI/MONAILabel\">module documentation")
+set(EXTENSION_DESCRIPTION "This extension helps to run chain of MONAI transforms and visualize every stage over an image/label. See more information in <a href=\"https://github.com/Project-MONAI/MONAILabel\">MONAILabel documentation</a>.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/Project-MONAI/SlicerMONAIViz/main/MONAIViz/Resources/Icons/MONAIViz.png")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/1.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/2.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/3.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/4.jpg")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies


### PR DESCRIPTION
Link was not formatted correctly and link text was incorrect.

I was not sure if the link should point to MONAI or MONAILabel - kept MONAILabel.