### PR TITLE
fixes loading bundle

### DIFF
--- a/MONAIViz/MONAIViz.py
+++ b/MONAIViz/MONAIViz.py
@@ -338,7 +338,7 @@ class MONAIVizWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             print(f"Importing Transform: {name} => {args}")
             # table.setCellWidget(pos, 0, EditButtonsWidget())
             box = qt.QCheckBox()
-            table.setCellWidget(box)
+            table.setCellWidget(pos, 0, box)
             item = qt.QTableWidgetItem()
             item.setIcon(self.icon("icons8-yellow-circle-48.png"))
             table.setItem(pos, 1, item)


### PR DESCRIPTION
```
  File "//Documents/SlicerMONAIViz/MONAIViz/MONAIViz.py", line 341, in onImportBundle
    table.setCellWidget(box)
ValueError: Called setCellWidget(int row, int column, QWidget widget) -> void with wrong number of arguments: (QCheckBox(0x600003d3d340) ,)
```